### PR TITLE
(bug) Move cookieparser and express-session to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   "homepage": "https://github.com/boundry/boundry",
   "devDependencies": {
     "chai": "^1.10.0",
-    "cookie-parser": "^1.3.3",
-    "express-session": "^1.9.3",
     "karma": "^0.12.31",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.1.10",
@@ -40,6 +38,7 @@
   },
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
+    "express-session": "^1.9.3",
     "bluebird": "^2.4.0",
     "body-parser": "^1.10.0",
     "bookshelf": "^0.7.9",
@@ -47,6 +46,7 @@
     "express": "^4.10.6",
     "knex": "^0.7.3",
     "morgan": "^1.5.0",
+    "cookie-parser": "^1.3.3",
     "mysql": "^2.5.4"
   }
 }


### PR DESCRIPTION
Since heroku only installs prod dependencies, it wasn't installing these
modules, crashing our prod server.