### PR TITLE
(bug) Remove FK restriction in locationData table. Closes #109.

### DIFF
--- a/migrations/20141230195746_migrate_test.js
+++ b/migrations/20141230195746_migrate_test.js
@@ -53,9 +53,9 @@ exports.up = function(knex) {
           locationData.increments('id').primary();
           locationData.decimal('latitude', 10, 6);
           locationData.decimal('longitude', 10, 6);
-          locationData.integer('user_id', 10).unsigned().references('user.id');
-          locationData.integer('event_id', 10).unsigned().references('event.id');
-          locationData.integer('region_id', 10).unsigned().references('region.id');
+          locationData.string('user_id', 255); //NEED
+          locationData.integer('event_id', 10).unsigned(); //NEED
+          locationData.integer('region_id', 10).unsigned(); //NEED
           locationData.timestamps();
         })
 
@@ -86,6 +86,7 @@ exports.down = function(knex) {
     return knex.schema.dropTableIfExists(table).then(function() { return memo++; });
   }, 0)
   .finally(function(){
+    console.log('TABLES DROPPED');
     return knex.raw('SET foreign_key_checks = 1;');
   });
 };


### PR DESCRIPTION
Quick and dirty fix. SQL only allows foreign keys to be referenced in ONE other table. Interestingly, our schema has been violating this for a while without any complaint from Bookshelf or SQL. But the locationData table tried to use FKs a third time, which error'd out. This does not modify the locationData fields; it merely removes their FK constraints. 