### PR TITLE
(feat) Build out event dashboard

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -20,12 +20,12 @@ angular
       controller: 'AuthSignupCtrl',
    })
    .state('eventDashboard', {
-      url: '/eventdash',
+      url: '/events/{organizerEmail}',
       templateUrl: 'app/eventDashboard/eventDashboard.html',
       controller: 'EventDashboardCtrl',
    })
    .state('eventEditor', {
-      url: '/event',
+      url: '/editor/{eventId}',
       templateUrl: 'app/eventEditor/eventEditor.html',
       controller: 'EventEditorCtrl',
    })

--- a/client/app/eventDashboard/eventDashboard.html
+++ b/client/app/eventDashboard/eventDashboard.html
@@ -1,5 +1,7 @@
 <div>
 <h1>Event Dashboard</h1>
-<div ng-model='eventData'>{{ eventData }}</div>
+
+<div ng-repeat='event in eventData' ui-sref='eventEditor({eventId: event.id,
+  regions: event.regions})'> {{ event.name }} {{ event.id }}</div>
 
 </div>

--- a/client/app/eventDashboard/eventDashboardCtrl.js
+++ b/client/app/eventDashboard/eventDashboardCtrl.js
@@ -4,12 +4,20 @@ angular
 
   EventDashboardCtrl.$inject = [
     '$scope',
+    '$stateParams',
     'EventDashboardFactory'
   ];
 
-  function EventDashboardCtrl ($scope, EventDashboardFactory, uiGmapGoogleMapApi) {
-    EventDashboardFactory.getEvents()
+  function EventDashboardCtrl ($scope, $stateParams, EventDashboardFactory, uiGmapGoogleMapApi) {
+    angular.extend($scope, EventDashboardFactory);
+
+    $scope.getEvents($stateParams.organizerEmail) //Get events for organizer, passing in $stateParams.organizer
       .success(function(data) {
-        $scope.eventData = data;
+        $scope.setEventData(data); //Set data on factory
+        $scope.eventData = $scope.getEventData();
+        console.log($scope.eventData);
+      })
+      .error(function(error) {
+        console.log(error);
       });
   }

--- a/client/app/eventDashboard/eventDashboardService.js
+++ b/client/app/eventDashboard/eventDashboardService.js
@@ -5,15 +5,30 @@ angular
   EventDashboardFactory.$inject = ['$http'];
 
   function EventDashboardFactory ($http) {
+    var eventData; //Set by controller after promise returns
 
     return {
-      getEvents: getEvents
+      getEvents: getEvents,
+      setEventData: setEventData,
+      getEventData: getEventData
     };
 
+
+    //Getter/setter for eventData
+    function setEventData (data) {
+      eventData = data;
+    }
+    function getEventData () {
+      return eventData;
+    }
+    //TODO: This smells bad. Data should be resolved in the factory, not the in
+    //the controller. Plus now all controllers that import that need to know
+    //that getEvents returns a promise. 
     //Get all event data for an organizer
     function getEvents (organizerEmail) {
       organizerEmail = organizerEmail || 'test@org.com';
       var url = '/api/web/organizer/' + organizerEmail + '/events';
+      console.log(url);
       return $http.get(url);
     }
   }

--- a/client/app/eventEditor/eventEditorCtrl.js
+++ b/client/app/eventEditor/eventEditorCtrl.js
@@ -5,12 +5,17 @@ angular
   EventEditorCtrl.$inject = [
     '$scope',
     '$http',
+    '$stateParams',
     'EventEditorFactory',
+    'EventDashboardFactory',
     'uiGmapGoogleMapApi',
     'uiGmapLogger'
   ];
 
-  function EventEditorCtrl ($scope, $http, EventEditorFactory, uiGmapGoogleMapApi, uiGmapLogger) {
+  function EventEditorCtrl ($scope, $http, $stateParams, EventEditorFactory, EventDashboardFactory, uiGmapGoogleMapApi, uiGmapLogger) {
+    console.log($stateParams);
+    console.log(EventDashboardFactory.getEventData());
+
     uiGmapLogger.doLog = true;
     angular.extend($scope, EventEditorFactory);
     


### PR DESCRIPTION
Async call to server stores event data in the dashboard service which can then
be shared across the event dash and event editor views. Event dash correctly
displays an organizer's (as specified in url param) events and ui-srefs to the
event editor, passing along each event id.