### PR TITLE
(refactor) Change event dash to pull organizer from factory

### DIFF
--- a/client/app/eventDashboard/eventDashboardCtrl.js
+++ b/client/app/eventDashboard/eventDashboardCtrl.js
@@ -4,18 +4,16 @@ angular
 
   EventDashboardCtrl.$inject = [
     '$scope',
-    '$stateParams',
     'EventDashboardFactory'
   ];
 
-  function EventDashboardCtrl ($scope, $stateParams, EventDashboardFactory, uiGmapGoogleMapApi) {
+  function EventDashboardCtrl ($scope, EventDashboardFactory, uiGmapGoogleMapApi) {
     angular.extend($scope, EventDashboardFactory);
 
-    $scope.getEvents($scope.currentOrganizerEmail) //Get events for organizer, passing in $stateParams.organizer
+    $scope.getEvents($scope.currentOrganizerEmail) //Get events for organizer, passing in email pulled from dashboard factory which is pulled from auth factory 
       .success(function(data) {
         $scope.setEventData(data); //Set data on factory
         $scope.eventData = $scope.getEventData();
-        console.log($scope.eventData);
       })
       .error(function(error) {
         console.log(error);

--- a/client/app/eventDashboard/eventDashboardService.js
+++ b/client/app/eventDashboard/eventDashboardService.js
@@ -30,7 +30,6 @@ angular
     function getEvents (organizerEmail) {
       organizerEmail = organizerEmail || 'test@org.com';
       var url = '/api/web/organizer/' + organizerEmail + '/events';
-      console.log(url);
       return $http.get(url);
     }
   }

--- a/client/app/eventEditor/eventEditor.html
+++ b/client/app/eventEditor/eventEditor.html
@@ -30,7 +30,7 @@
     </ui-gmap-drawing-manager>
 
     <ui-gmap-polygon
-      ng-repeat="poly in polygons"
+      ng-repeat="poly in currEventData.regions"
       events='polygonEvents'
       path='poly.region_attr.coordinates'
       fill='poly.region_attr.fill'
@@ -44,7 +44,6 @@
   </ui-gmap-google-map>
 
   <button ng-click="savePolygons()">SAVE</button>
-  <button ng-click="getPolygons()">RETRIEVE</button>
-  <div ng-model="polygons">{{ polygons }}</div>
+  <div ng-model="currEventData">{{ currEventData }}</div>
 
 </div>

--- a/client/app/eventEditor/eventEditorCtrl.js
+++ b/client/app/eventEditor/eventEditorCtrl.js
@@ -7,20 +7,22 @@ angular
     '$http',
     '$stateParams',
     'EventEditorFactory',
-    'EventDashboardFactory',
     'uiGmapGoogleMapApi',
     'uiGmapLogger'
   ];
 
-  function EventEditorCtrl ($scope, $http, $stateParams, EventEditorFactory, EventDashboardFactory, uiGmapGoogleMapApi, uiGmapLogger) {
-    console.log($stateParams);
-    console.log(EventDashboardFactory.getEventData());
+  function EventEditorCtrl ($scope, $http, $stateParams, EventEditorFactory, uiGmapGoogleMapApi, uiGmapLogger) {
 
     uiGmapLogger.doLog = true;
     angular.extend($scope, EventEditorFactory);
+
+
+    //Take data from EventDashboard (via EventEditorFactory) and save to scope
+    $scope.currEventData = EventEditorFactory.grabEventData($stateParams.eventId);
+    console.log('currEventData', $scope.currEventData);
     
     //TODO: Get polygons from server
-    $scope.polygons = [];
+    $scope.polygons = []; //gmap directive pulls from here to render shapes
     $scope.drawingManagerControl = {};
 
     //uiGmpaGoogleMapApi is a promise. "then" callback provides the google.maps

--- a/client/app/eventEditor/eventEditorService.js
+++ b/client/app/eventEditor/eventEditorService.js
@@ -2,9 +2,9 @@ angular
   .module('boundry.eventEditor', [])
   .factory('EventEditorFactory', EventEditorFactory);
   
-  EventEditorFactory.$inject = ['$http'];
+  EventEditorFactory.$inject = ['$http', 'EventDashboardFactory'];
 
-  function EventEditorFactory ($http) {
+  function EventEditorFactory ($http, EventDashboardFactory) {
     //TODO: Break all these options into a separate config file
     var polygonOptions = {
       fillColor: '#ffff00',
@@ -51,11 +51,15 @@ angular
     return {
       basicOptions: basicOptions,
       extraOptions: extraOptions,
+
       polygonOptions: polygonOptions,
       polygonEvents: polygonEvents,
       Polygon: Polygon,
+
       savePolygons: savePolygons,
-      getPolygons: getPolygons
+      getPolygonsFromServer: getPolygonsFromServer,
+
+      grabEventData: grabEventData
     };
 
     //Polygon constructor. Takes gMaps path array, converts key strings, adds
@@ -95,7 +99,7 @@ angular
     }
 
     //Retrieves all polygons for a given eventId
-    function getPolygons (eventId) {
+    function getPolygonsFromServer (eventId) {
       var scope = this;
 
       //$http.get('/polygontest')
@@ -106,6 +110,20 @@ angular
           });
         })
         .error(logError);
+    }
+
+    //Gets event data for specific event from Dashboard Factory
+    function grabEventData(eventId) {
+      //Grab all event data from Dashboard Service
+      var allEvents = EventDashboardFactory.getEventData();
+
+      //Match with the given eventId
+      for (var i = 0; i < allEvents.length; i++) {
+        if (parseInt(eventId) === allEvents[i].id) {
+          return allEvents[i];
+        }
+      }
+      console.log('Could not get event data for event id: ', eventId);
     }
 
     //POSTs polygon data to server for saving

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -8,4 +8,4 @@
 #vertices {
   width: 100%;
 }
-.angular-google-map-container { height: 600px; }
+.angular-google-map-container { height: 300px; }


### PR DESCRIPTION
Also refactors event editor to pull event data from event dash factory. This
minimizes server requests and allows us to modify the entire event from the
event editor, not just the regions.