### PR TITLE
(bug) Fix multiple polygon saving issue. Closes #167.

### DIFF
--- a/client/app/eventDashboard/eventDashboardService.js
+++ b/client/app/eventDashboard/eventDashboardService.js
@@ -2,9 +2,9 @@ angular
   .module('boundry.eventDashboard', [])
   .factory('EventDashboardFactory', EventDashboardFactory);
 
-  EventDashboardFactory.$inject = ['$http', 'AuthFactory'];
+  EventDashboardFactory.$inject = ['$rootScope', '$http', 'AuthFactory'];
 
-  function EventDashboardFactory ($http, AuthFactory) {
+  function EventDashboardFactory ($rootScope, $http, AuthFactory) {
     var eventData; //Set by controller after promise returns
     //TODO: This should be called anew from the controller, so the email doesn't
     //persist here after the user logs out. 
@@ -21,6 +21,7 @@ angular
     //Getter/setter for eventData
     function setEventData (data) {
       eventData = data;
+      $rootScope.$emit('eventDataUpdated');
     }
     function getEventData () {
       return eventData;

--- a/client/app/eventEditor/eventEditor.html
+++ b/client/app/eventEditor/eventEditor.html
@@ -9,6 +9,7 @@
   <!--<script type="text/ng-template" id="searchBox.template.html">-->
     <!--<input type="text"  placeholder="Search Address"/>-->
   <!--</script>-->
+  <button ng-click="sendEventDataToServerAndRefresh()">SAVE</button>
   <ng-region-editor></ng-region-editor>
 
   <ui-gmap-google-map center='basicOptions.center' 
@@ -42,6 +43,5 @@
 
   </ui-gmap-google-map>
 
-  <button ng-click="sendEventDataToServer()">SAVE</button>
   <div ng-model="currEventData">{{ currEventData }}</div>
 </div>

--- a/client/app/eventEditor/eventEditorCtrl.js
+++ b/client/app/eventEditor/eventEditorCtrl.js
@@ -23,6 +23,19 @@ angular
     $scope.currEventData = EventEditorFactory.grabEventData($stateParams.eventId);
     console.log('currEventData', $scope.currEventData);
 
+    //Listen to data changes on the factory and reset the scope data to match.
+    //This is lets us grab the region IDs that the server generates for newly
+    //created polygons and set them on the scope so we don't keep saving them
+    //with null IDs
+    var unbind = $rootScope.$on('eventDataUpdated', function (event) {
+      event.stopPropagation();
+
+      $scope.currEventData = EventEditorFactory.grabEventData($stateParams.eventId);
+      console.log('updatedCurrEventData', $scope.currEventData);
+    });
+
+    $scope.$on('$destroy', unbind);
+
     //Save event listeners to scope for use by polygon directive. Used to live
     //in factory but the handler needs to call something on the scope.
     $scope.polygonEvents = {

--- a/client/app/eventEditor/eventEditorService.js
+++ b/client/app/eventEditor/eventEditorService.js
@@ -40,7 +40,7 @@ angular
       Polygon: Polygon,
 
       savePolygons: savePolygons,
-      sendEventDataToServer: sendEventDataToServer,
+      sendEventDataToServerAndRefresh: sendEventDataToServerAndRefresh,
       getPolygonsFromServer: getPolygonsFromServer,
 
       grabEventData: grabEventData
@@ -109,7 +109,7 @@ angular
       console.log('Could not get event data for event id: ', eventId);
     }
 
-    function sendEventDataToServer () {
+    function sendEventDataToServerAndRefresh () {
       var scope = this;
       //TODO: This is bad. Factory shouldn't be grabbing stuff from controller.
       //Clicking a save button should just update the data in the factory (model) 
@@ -118,7 +118,20 @@ angular
       var organizerEmail = EventDashboardFactory.currentOrganizerEmail;
 
       $http.post('/api/web/organizer/' + organizerEmail + '/events', data)
-        .success(logSuccess)
+        .success(function(data, status) {
+          logSuccess(data, status);
+
+          //Get the fresh data from the server, with the server-generated IDs
+          //for newly created regions
+          EventDashboardFactory.getEvents(organizerEmail)
+            .success(function(data) {
+              //Set it on the factory
+              EventDashboardFactory.setEventData(data);
+            }) 
+            .error(function(error) {
+              console.log(error);
+            });
+        })
         .error(logError);
     }
 

--- a/server/routes/web/webApiRouter.js
+++ b/server/routes/web/webApiRouter.js
@@ -129,7 +129,7 @@ var postEvent = function(req,res) {
 
               }
             });
-              res.status(300).send('updated');
+              res.status(200).send('updated');
           });
         } else {
           //save new event to event table

--- a/server/server.js
+++ b/server/server.js
@@ -20,7 +20,6 @@ app.use(bodyParser.json());
 app.use(cookieParser());
 app.use(cors());
 app.use(morgan('tiny'));
-console.log(path.join(__dirname, '/../client'));
 app.use(express.static(path.join(__dirname, '/../client/')));
 
 //Application


### PR DESCRIPTION
Saving event data in the editor now also pulls the latest version of that data
from the server (after our DB generates IDs for new regions). We then set that
data on the dashboard factory as before, but the factory now emits an event in
the process, which is heard by the editor controller which causes it to refresh
the data on its scope with the latest version from the factory.