### PR TITLE
(feat) Implement event deletion on client and server. Closes #178.

### DIFF
--- a/client/app/eventDashboard/eventDashboard.html
+++ b/client/app/eventDashboard/eventDashboard.html
@@ -7,21 +7,15 @@
   <div id='yourEvents'>
     <div id='yourEvTitle'>Your Events</div>
 
-<!-- <<<<<<< HEAD
-    <div id="eventsAndMap">
-      <div id="leftCol">
-        <div id="createEvBtn"><input id="btn" type="button" value="Create Event"
-          ng-click="createNewEvent()"></div>
-======= -->
     <div id='eventsAndMap'>
       <div id='leftCol'>
-        <div id='createEvBtn'><input id='btn' type='button' value='Create Event' ui-sref='eventEditor()'></div>
+        <div id='createEvBtn'><input id='btn' type='button' value='Create Event' ng-click='createNewEvent()'></div>
         <div id="noEventMessage" ng-show='hasEvent'>{{eventMessage}}</div>
-<!-- >>>>>>> (feat) styling of login/signup. Change color theme -->
 
         <div id='eventList' ng-repeat='event in eventData'>
             <ul id='evSpan'>
-              <input id='btn' class='editBtn' type='button' value='Edit' ui-sref='eventEditor({eventId: event.id, regions: event.regions})'>
+              <input id="btn" class="editBtn" type="button" value="Del" ng-click="deleteEvent(event.id)">
+              <input id="btn" class="editBtn" type="button" value="Edit" ui-sref='eventEditor({eventId: event.id, regions: event.regions})'>
               <li id='eventName' ng-class='{evNameInList: hover}' ng-mouseenter='populateMap($index); hover = true' ng-mouseleave='hover = false'>
           {{ event.name }}</li>
             </ul>

--- a/client/app/eventDashboard/eventDashboardService.js
+++ b/client/app/eventDashboard/eventDashboardService.js
@@ -15,6 +15,7 @@ angular
 
     return {
       createNewEvent: createNewEvent,
+      deleteEvent: deleteEvent,
       sendEventDataToServerAndRefresh: sendEventDataToServerAndRefresh,
       getEvents: getEvents,
       setEventData: setEventData,
@@ -35,6 +36,23 @@ angular
       sendEventDataToServerAndRefresh(newEvent);
     }
 
+    function deleteEvent(eventId) {
+      $http.delete('api/web/organizer/events/' + eventId)
+        .success(function(data, status) {
+          var organizerEmail = AuthFactory.getEmail();
+          getEvents(organizerEmail)
+          .success(function(data) {
+            //Set it on the factory
+            setEventData(data);
+          }) 
+          .error(function(error) {
+            console.log(error);
+          });
+        })
+      .error(function(error) {
+        console.log(error);
+      });
+    }
 
     //Takes an event data object, sends it to server, then refreshes dashboard
     //factory with the latest data (and newly server-generated IDs)


### PR DESCRIPTION
Makes a delete event button on client and web api router function on server.
Client function makes a DELETE requests with an event ID. Server takes that ID,
fetches the event with its related regions and those regions' related actions,
and then deletes everything in the right order given their foreign key
relationships. On success, client makes another server request for fresh data
and refreshes the dashboard.