### PR TITLE
(feat) Fix polygon creation; drawing one auto loads its action data.

### DIFF
--- a/client/app/eventDashboard/eventDashboardService.js
+++ b/client/app/eventDashboard/eventDashboardService.js
@@ -80,7 +80,6 @@ angular
     //Getter/setter for eventData
     function setEventData (data) {
       eventData = data;
-      console.log('data:',data);
       if (data.length === 0) {
         createNewEvent();
       }

--- a/client/app/eventEditor/eventEditorCtrl.js
+++ b/client/app/eventEditor/eventEditorCtrl.js
@@ -100,6 +100,7 @@ angular
           //Here, polygon belongs to the Drawing Manager. Empty the path so we
           //don't display it in addition to our newly constructed polygon.
           polygon.overlay.setPath([]);           
+          $rootScope.$emit('regionClicked', newPolygon); //Load new polygon's action data for editing
           $scope.$apply(); //Re-render map from newly updated scope storage
         });
       });


### PR DESCRIPTION
Now when you draw a region you can immediately edit it's action data without
having to click on it again with the hand tool.